### PR TITLE
Correct minor errors with const-ification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,27 @@ endif()
 
 project (dynamic)
 
+include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+
+# sparsepp
+ExternalProject_Add(sparsepp
+  GIT_REPOSITORY "https://github.com/edawson/sparsepp.git"
+  GIT_TAG "1c5a285e87b2244383efe0398f9992acd61234e9"
+  BUILD_IN_SOURCE TRUE
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR} # TODO ADD static build flag
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND ""
+  CONFIGURE_COMMAND "")
+ExternalProject_Get_property(sparsepp INSTALL_DIR)
+set(sparsepp_INCLUDE "${INSTALL_DIR}/src/sparsepp/sparsepp/")
+set(sparsepp_LIB "${INSTALL_DIR}/src/sparsepp/sparsepp/")
+
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/include/internal)
 include_directories(${PROJECT_SOURCE_DIR}/include/algorithms)
 include_directories(${PROJECT_SOURCE_DIR}/include/algorithms/cw-bwt)
+include_directories(${INSTALL_DIR}/src/sparsepp/sparsepp)
 
 message("Building in ${CMAKE_BUILD_TYPE} mode")
 
@@ -31,3 +48,13 @@ add_executable(h0_lz77 h0_lz77.cpp)
 add_executable(rle_bwt rle_bwt.cpp)
 add_executable(cw-bwt cw-bwt.cpp)
 add_executable(benchmark benchmark.cpp)
+
+add_dependencies(debug sparsepp)
+add_dependencies(debug-alan sparsepp)
+add_dependencies(rle_lz77_v1 sparsepp)
+add_dependencies(rle_lz77_v2 sparsepp)
+add_dependencies(h0_lz77 sparsepp)
+add_dependencies(rle_bwt sparsepp)
+add_dependencies(cw-bwt sparsepp)
+add_dependencies(benchmark sparsepp)
+

--- a/include/algorithms/rle_lz77_v1.hpp
+++ b/include/algorithms/rle_lz77_v1.hpp
@@ -341,7 +341,7 @@ private:
 
 	//suffix array samples (two per BWT run)
 	//one (sparse) vector of samples per character
-	map<char_t,sparse_vec> SA;
+    spp::sparse_hash_map<char_t,sparse_vec> SA;
 
 };
 

--- a/include/internal/alphabet_encoder.hpp
+++ b/include/internal/alphabet_encoder.hpp
@@ -22,7 +22,6 @@
 #define INCLUDE_INTERNAL_ALPHABET_ENCODER_HPP_
 
 #include "includes.hpp"
-#include <map>
 
 namespace dyn {
 
@@ -227,7 +226,7 @@ public:
 		out.write((char*)&decode_size,sizeof(decode_size));
 		w_bytes += sizeof(decode_size);
 
-		for(map<char_type,vector<bool> >::value_type e : encode_){
+		for(spp::sparse_hash_map<char_type,vector<bool> >::value_type e : encode_){
 
 			out.write((char*)&e.first,sizeof(e.first));
 			w_bytes += sizeof(e.first);
@@ -237,7 +236,7 @@ public:
 
 		}
 
-		for(map<vector<bool>, char_type>::value_type d : decode_){
+		for(spp::sparse_hash_map<vector<bool>, char_type>::value_type d : decode_){
 
 			auto B = d.first;
 			w_bytes += serialize_vec_bool(out, B);
@@ -490,10 +489,10 @@ private:
 
 
 
-	map<char_type,vector<bool> > encode_;
+    spp::sparse_hash_map<char_type,vector<bool> > encode_;
 
 	//char_type value 0 is reserved
-	map<vector<bool>, char_type> decode_;
+    spp::sparse_hash_map<vector<bool>, char_type> decode_;
 
 	uint64_t sigma;
 

--- a/include/internal/alphabet_encoder.hpp
+++ b/include/internal/alphabet_encoder.hpp
@@ -174,7 +174,7 @@ public:
 
 	bool char_exists(char_type c) const {
 
-		return encode_.find(c) != encode_end.() && encode_.at(c).size()>0;
+		return encode_.find(c) != encode_.end() && encode_.at(c).size()>0;
 
 	}
 

--- a/include/internal/alphabet_encoder.hpp
+++ b/include/internal/alphabet_encoder.hpp
@@ -174,7 +174,7 @@ public:
 
 	bool char_exists(char_type c) const {
 
-		return encode_.at(c).size()>0;
+		return encode_.find(c) != encode_end.() && encode_.at(c).size()>0;
 
 	}
 

--- a/include/internal/includes.hpp
+++ b/include/internal/includes.hpp
@@ -21,7 +21,7 @@
 #include <fstream>
 #include <sstream>
 #include <cassert>
-#include <map>
+#include "spp.h"
 #include <cmath>
 #include <algorithm>
 

--- a/include/internal/packed_vector.hpp
+++ b/include/internal/packed_vector.hpp
@@ -569,7 +569,9 @@ namespace dyn{
       /* set i-th element to x. updates psum */
       void set(uint64_t i, uint64_t x){
 
-	 assert(bitsize(x) <= width_);
+          if (bitsize(x) > width_) {
+              return rebuild_set(i, x);
+          }
 
 	 auto y = at(i);
 

--- a/include/internal/rle_string.hpp
+++ b/include/internal/rle_string.hpp
@@ -641,7 +641,7 @@ private:
 	sparse_bitvector_t runs;
 
 	//for each letter, its runs stored contiguously
-	map<char_type,sparse_bitvector_t> runs_per_letter;
+    spp::sparse_hash_map<char_type,sparse_bitvector_t> runs_per_letter;
 
 	//store run heads in a compressed string supporting access/rank/select/insert
 	string_t run_heads_;

--- a/include/internal/spsi.hpp
+++ b/include/internal/spsi.hpp
@@ -21,6 +21,7 @@
 #define INTERNAL_SPSI_HPP_
 
 #include "includes.hpp"
+#include "packed_vector.hpp"
 
 namespace dyn{
 
@@ -379,8 +380,8 @@ namespace dyn{
 	  */
 	 node(const node & n){
 
-	    subtree_sizes = {n.subtree_sizes};
-	    subtree_psums = {n.subtree_psums};
+         subtree_sizes = {n.subtree_sizes};
+         subtree_psums = {n.subtree_psums};
 
 	    if(n.has_leaves_){
 
@@ -420,8 +421,8 @@ namespace dyn{
 	  */
 	 node(){
 
-	    subtree_sizes = vector<uint64_t>(2*B+2);
-	    subtree_psums = vector<uint64_t>(2*B+2);
+         subtree_sizes = packed_vector(2*B+2,1);
+         subtree_psums = packed_vector(2*B+2,1);
 
 	    nr_children = 1;
 	    has_leaves_ = true;
@@ -440,8 +441,8 @@ namespace dyn{
 	    this->rank_ = rank;
 	    this->parent = P;
 
-	    subtree_sizes = vector<uint64_t>(2*B+2);
-	    subtree_psums = vector<uint64_t>(2*B+2);
+	    subtree_sizes = packed_vector(2*B+2,1);
+	    subtree_psums = packed_vector(2*B+2,1);
 
 	    uint64_t si = 0;
 	    uint64_t ps = 0;
@@ -482,8 +483,8 @@ namespace dyn{
 	    this->rank_ = rank;
 	    this->parent = P;
 
-	    subtree_sizes = vector<uint64_t>(2*B+2);
-	    subtree_psums = vector<uint64_t>(2*B+2);
+	    subtree_sizes = packed_vector(2*B+2,1);
+	    subtree_psums = packed_vector(2*B+2,1);
 
 	    assert(c.size()<=2*B+2);
 
@@ -513,9 +514,9 @@ namespace dyn{
 	 uint64_t bit_size() const {
 	    uint64_t bs = 8*sizeof(node);
 
-	    bs += subtree_sizes.capacity()*sizeof(uint64_t)*8;
+	    bs += subtree_sizes.bit_size();
 
-	    bs += subtree_psums.capacity()*sizeof(uint64_t)*8;
+	    bs += subtree_psums.bit_size();
 
 	    bs += children.capacity()*sizeof(node*)*8;
 
@@ -1446,12 +1447,12 @@ namespace dyn{
 
 	    assert(nr_children>0);
 	    assert(nr_children-1 < subtree_sizes.size());
-	    return subtree_sizes[nr_children-1];
+	    return subtree_sizes.at(nr_children-1);
 
 	 }
 
 	 uint64_t psum() const {
-	    return subtree_psums[nr_children-1];
+         return subtree_psums.at(nr_children-1);
 	 }
 
 	 void overwrite_parent(node *P){
@@ -1483,12 +1484,9 @@ namespace dyn{
 	    out.write((char*)&leaves_len,sizeof(leaves_len));
 	    w_bytes += sizeof(leaves_len);
 
+        w_bytes += subtree_sizes.serialize(out);
 
-	    out.write((char*)subtree_sizes.data(),sizeof(uint64_t)*subtree_sizes_len);
-	    w_bytes += sizeof(uint64_t)*subtree_sizes_len;
-
-	    out.write((char*)subtree_psums.data(),sizeof(uint64_t)*subtree_psums_len);
-	    w_bytes += sizeof(uint64_t)*subtree_psums_len;
+        w_bytes += subtree_psums.serialize(out);
 
 	    out.write((char*)&has_leaves_,sizeof(has_leaves_));
 	    w_bytes += sizeof(has_leaves_);
@@ -1531,11 +1529,9 @@ namespace dyn{
 	    assert(subtree_sizes_len>0);
 	    assert(subtree_psums_len>0);
 
-	    subtree_sizes = vector<uint64_t>(subtree_sizes_len);
-	    in.read((char*)subtree_sizes.data(),sizeof(uint64_t)*subtree_sizes_len);
+        subtree_sizes.load(in);
 
-	    subtree_psums = vector<uint64_t>(subtree_psums_len);
-	    in.read((char*)subtree_psums.data(),sizeof(uint64_t)*subtree_psums_len);
+        subtree_psums.load(in);
 
 
 	    in.read((char*)&has_leaves_,sizeof(has_leaves_));
@@ -1877,8 +1873,8 @@ namespace dyn{
 	  * in the following 2 vectors, the first nr_subtrees+1 elements refer to the
 	  * nr_subtrees subtrees
 	  */
-	 vector<uint64_t> subtree_sizes;
-	 vector<uint64_t> subtree_psums;
+	 packed_vector subtree_sizes;
+	 packed_vector subtree_psums;
 
 	 vector<node*> children;
 	 vector<leaf_type*> leaves;

--- a/include/internal/wt_string.hpp
+++ b/include/internal/wt_string.hpp
@@ -93,7 +93,7 @@ namespace dyn{
        */
       char_type operator[](uint64_t i){
 
-	 return at(i);
+          return root[i];
 
       }
 

--- a/include/internal/wt_string.hpp
+++ b/include/internal/wt_string.hpp
@@ -93,7 +93,7 @@ namespace dyn{
        */
       char_type operator[](uint64_t i){
 
-          return root[i];
+          return at(i);
 
       }
 


### PR DESCRIPTION
This resolves some mistakes I made when const-ifying the library.

The main problem was in the alphabet encoder. To check if the character exists, we need to query the encoding map using the appropriate query, or else we will segfault.

@nicolaprezza I do have some questions about the encoder class. The use of a map to hold the encodings seems problematic for large alphabets where we are only using each character a handful of times. This will lead to the alphabet encoding itself taking a lot of space.