### PR TITLE
dynamic wavelet matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ CMakeLists.txt~
 debug.cpp~
 gap_bv_benchmark.txt
 README.md~
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(h0_lz77 h0_lz77.cpp)
 add_executable(rle_bwt rle_bwt.cpp)
 add_executable(cw-bwt cw-bwt.cpp)
 add_executable(benchmark benchmark.cpp)
+add_executable(wm_string wm_string.cpp)
 
 add_dependencies(debug hopscotch_map)
 add_dependencies(rle_lz77_v1 hopscotch_map)
@@ -61,4 +62,5 @@ add_dependencies(h0_lz77 hopscotch_map)
 add_dependencies(rle_bwt hopscotch_map)
 add_dependencies(cw-bwt hopscotch_map)
 add_dependencies(benchmark hopscotch_map)
+add_dependencies(wm_string hopscotch_map)
 

--- a/include/dynamic.hpp
+++ b/include/dynamic.hpp
@@ -85,7 +85,7 @@ typedef wt_string<gap_bv> wtgap_str;
 /*
  * succinct/compressed BWT (see description of com_str)
  */
-typedef bwt<wm_str,rle_str> wt_bwt;
+typedef bwt<wt_str,rle_str> wt_bwt;
 
 /*
  * run-length encoded BWT

--- a/include/dynamic.hpp
+++ b/include/dynamic.hpp
@@ -23,6 +23,7 @@
 #include <internal/hacked_vector.hpp>
 #include <internal/lciv.hpp>
 #include <internal/wt_string.hpp>
+#include <internal/wm_string.hpp>
 #include <internal/fm_index.hpp>
 
 namespace dyn{
@@ -56,6 +57,11 @@ typedef succinct_bitvector<spsi<packed_bit_vector,8192,16>> suc_bv;
  * user can choose (at construction time) between fixed-length / gamma / Huffman encoding of characters.
  */
 typedef wt_string<suc_bv> wt_str;
+
+/*
+ * succinct/compressed dynamic string implemented with a wavelet matrix.
+ */
+typedef wm_string<succinct_bitvector<spsi<packed_bit_vector,256,16>>> wm_str;
 
 /*
  * run-length encoded (RLE) string. This string uses 1 sparse bitvector

--- a/include/dynamic.hpp
+++ b/include/dynamic.hpp
@@ -85,7 +85,7 @@ typedef wt_string<gap_bv> wtgap_str;
 /*
  * succinct/compressed BWT (see description of com_str)
  */
-typedef bwt<wt_str,rle_str> wt_bwt;
+typedef bwt<wm_str,rle_str> wt_bwt;
 
 /*
  * run-length encoded BWT

--- a/include/internal/wm_string.hpp
+++ b/include/internal/wm_string.hpp
@@ -29,11 +29,13 @@ public:
     std::vector<dynamic_bitvector_t> bit_arrays;
     std::vector<ulint> begin_one;               // 各bitの1の開始位置
 
-    ulint size;                                 // 与えられた配列のサイズ
-    ulint maximum_element;                      // 最大の文字
-    ulint bit_size;                             // 文字を表すのに必要なbit数
+    ulint size = 0;                                 // 与えられた配列のサイズ
+    ulint maximum_element = 0;                      // 最大の文字
+    ulint bit_size = 0;                             // 文字を表すのに必要なbit数
 
 public:
+    wm_string (void) { } // default constructor, for loading from file
+
     // max_element: 入ってくる中で一番大きい数値
     wm_string (ulint maximum_element) : size(0), maximum_element(maximum_element + 1) {
         this->bit_size = this->get_num_of_bit(maximum_element);

--- a/include/internal/wm_string.hpp
+++ b/include/internal/wm_string.hpp
@@ -5,17 +5,12 @@
 /*
  * wm_string.hpp
  *
- *  Created on: Jan 11, 2019
+ *  Created on: May 30, 2020
+ *      Author: MitI_7
  *      Author: Erik Garrison
  *
  *  Dynamic string supporting rank, select, access, insert.
- *
- *  The string uses a wavelet matrix representation. The encoding depends on the constructor:
- *
- *  - dynamic_string() : gamma coding. maximum code bit-length will be 2log sigma. New characters can always
- *     be inserted.
- *  - dynamic_string(uint64_t sigma) : fixed-length. Max sigma characters are allowed
- *  - dynamic_string(vector<pair<char_type,double> > P) : Huffman-encoding. The characters set is fixed at construction time.
+ *  Backed by a wavelet matrix based on the templated dynamic bitvector.
  *
  */
 
@@ -23,629 +18,250 @@
 #define INCLUDE_INTERNAL_WM_STRING_HPP_
 
 #include "includes.hpp"
-#include "alphabet_encoder.hpp"
 
 namespace dyn{
 
 template<class dynamic_bitvector_t>
+
 class wm_string{
 
 public:
+    std::vector<dynamic_bitvector_t> bit_arrays;
+    std::vector<ulint> begin_one;               // 各bitの1の開始位置
 
-    //we allow any alphabet
-    typedef uint64_t char_type;
-    typedef char_type value_type;
+    ulint size;                                 // 与えられた配列のサイズ
+    ulint maximum_element;                      // 最大の文字
+    ulint bit_size;                             // 文字を表すのに必要なbit数
 
-    /*
-     * Constructor #1
-     *
-     * Alphabet is unknown. Characters are gamma-coded
-     *
-     */
-    wm_string(){}
+public:
+    // max_element: 入ってくる中で一番大きい数値
+    wm_string (ulint maximum_element) : size(0), maximum_element(maximum_element + 1) {
+        this->bit_size = this->get_num_of_bit(maximum_element);
+        if (bit_size == 0) {
+            bit_size = 1;
+        }
+        this->begin_one.resize(bit_size);
 
-    /*
-     * Constructor #2
-     *
-     * We know only alphabet size. Each character is assigned log2(sigma) bits.
-     * Characters are assigned codes 0,1,2,... in order of appearance
-     *
-     */
-    wm_string(uint64_t sigma){
-
-        assert(sigma>0);
-        ae = alphabet_encoder(sigma);
-
-    }
-
-    /*
-     * Constructor #3
-     *
-     * We know character probabilities. Input: pairs <character, probability>
-     *
-     * Here the alphabet is Huffman encoded.
-     *
-     */
-    wm_string(vector<pair<char_type,double> >& P){
-
-        ae = alphabet_encoder(P);
-
-    }
-
-    template <typename t_str> wm_string( uint64_t sigma, t_str str ) : wm_string( sigma ) {
-        //this->wm_string( sigma ); //fixed alphabet size
-        for (size_t i = 0; i < str.size(); ++i) {
-            this->push_back( static_cast<char_type>(str[i]) );
+        for (ulint i = 0; i < bit_size; ++i) {
+            dynamic_bitvector_t sv;
+            bit_arrays.push_back(sv);
         }
     }
-      
-    /*
-     * number of bits in the bitvector
-     */
-    uint64_t size() const {
 
-        return n;
+    wm_string (ulint num_of_alphabet, const std::vector<ulint> &array) : size(0), maximum_element(num_of_alphabet + 1) {
+        this->bit_size = this->get_num_of_bit(num_of_alphabet);
+        if (bit_size == 0) {
+            bit_size = 1;
+        }
+        this->begin_one.resize(bit_size);
 
+        if (array.empty()) {
+            for (ulint i = 0; i < bit_size; ++i) {
+                dynamic_bitvector_t sv;
+                bit_arrays.push_back(sv);
+            }
+            return;
+        }
+
+        size = array.size();
+
+        std::vector<ulint> v(array), b(array.size(), 0);
+
+        for (ulint i = 0; i < bit_size; ++i) {
+
+            std::vector<ulint> temp;
+            // 0をtempにいれてく
+            for (ulint j = 0; j < v.size(); ++j) {
+                ulint c = v.at(j);
+                ulint bit = (c >> (bit_size - i - 1)) & 1;  //　上からi番目のbit
+                if (bit == 0) {
+                    temp.push_back(c);
+                    b[j] = 0;
+                }
+            }
+
+            this->begin_one.at(i) = temp.size();
+
+            // 1をtempにいれてく
+            for (ulint j = 0; j < v.size(); ++j) {
+                ulint c = v.at(j);
+                ulint bit = (c >> (bit_size - i - 1)) & 1;  //　上からi番目のbit
+                if (bit == 1) {
+                    temp.push_back(c);
+                    b[j] = 1;
+                }
+            }
+
+            dynamic_bitvector_t dbv;
+            for (auto& i : b) { dbv.push_back(i); }
+            bit_arrays.emplace_back(dbv);
+            v = temp;
+        }
     }
 
-    /*
-     * high-level access to the string. Supports assign (operator=) and access
-     */
-    char_type operator[](uint64_t i){
-
-        return at(i);
-
-    }
-
-    /*
-     * access
-     */
-    char_type at(uint64_t i) const {
-
-        assert(i<size());
-        return root.at(i);
-
-    }
-
-    /*
-     * position of i-th character equal to c. 0 =< i < rank(size(),c)
-     */
-    uint64_t select(uint64_t i,char_type c) const {
-
-        assert(ae.char_exists(c));
-        assert(i<rank(size(),c));
-
-        auto code = ae.encode_existing(c);
-
-        //if this fails, it means that c is not present
-        //in the string or that it is not present
-        //in the initial dictionary (if any)
-        assert(code.size()>0);
-
-        //this code must have been inserted in the tree already
-        assert(root.exists(code));
-
-        return root.select(i,code);
-
-    }
-
-    /*
-     * number of chars equal to c before position i EXCLUDED
-     */
-    uint64_t rank(uint64_t i, char_type c) const {
-
-        assert(i<=size());
-
-        if(not ae.char_exists(c)) return 0;
-
-        auto code = ae.encode_existing(c);
-
-        //if this fails, it means that c is not present
-        //in the string or that it is not present
-        //in the initial dictionary (if any)
-        assert(code.size()>0);
-
-        /*
-         * if condition is false, it means that the code is in the
-         * alphabet encoder, but it has not yet been inserted
-         * in the tree
-         */
-        return root.exists(code) ? root.rank(i,code) : 0;
-
-    }
-
-    bool char_exists(char_type c) const {
-
-        return ae.char_exists(c);
-
-    }
-
-    void push_back(char_type c){
-
-        insert(size(),c);
-
-    }
-
-    void push_front(char_type c){
-
-        insert(0,c);
-
-    }
-
-    /*
-     * insert a character at position i
-     */
-    void insert(uint64_t i, char_type c){
-
-        //get code of c
-        //if code does not yet exist, create it
-        auto code = ae.encode(c);
-
-        root.insert(i,code,c);
-
-        ++n;
-
-    }
-
-    /*
-     * remove character at position i
-     */
-    void remove( uint64_t i ) {
-        char_type c = this->at(i);
-        //get code of c
-        auto code = ae.encode(c);
-
-        root.remove( i, code, c );
-        --n;
-    }
-
-    uint64_t bit_size() const {
-        uint64_t size = 0;
-        size += sizeof(wm_string<dynamic_bitvector_t>)*8;
-        size += ae.bit_size();
-        size += root.bit_size();
-        return  size;
-
-    }
-
-    ulint alphabet_size(){
-
-        return ae.size();
-
-    }
-
-    ulint serialize(ostream &out)  {
-
-        ulint w_bytes=0;
-
-        out.write((char*)&n,sizeof(n));
-        w_bytes += sizeof(n);
-
-        w_bytes += root.serialize(out);
-
-        w_bytes += ae.serialize(out);
-
+    ulint serialize(ostream& out) const {
+        ulint w_bytes = 0;
+        out.write((char*)&size, sizeof(size));
+        w_bytes += sizeof(size);
+        out.write((char*)&maximum_element, sizeof(maximum_element));
+        w_bytes += sizeof(maximum_element);
+        out.write((char*)&bit_size, sizeof(bit_size));
+        w_bytes += sizeof(bit_size);
+        out.write((char*)begin_one.data(), sizeof(ulint) * bit_size);
+        w_bytes += sizeof(ulint) * bit_size;
+        for (auto& bv : bit_arrays) {
+            w_bytes += bv.serialize(out);
+        }
         return w_bytes;
-
     }
 
-    void load(istream &in){
-
-        in.read((char*)&n,sizeof(n));
-        root.load(in);
-        ae.load(in);
-
+    void load(istream& in) {
+        in.read((char*)&size, sizeof(size));
+        in.read((char*)&maximum_element, sizeof(maximum_element));
+        in.read((char*)&bit_size, sizeof(bit_size));
+        begin_one.resize(bit_size);
+        in.read((char*)begin_one.data(), sizeof(ulint) * bit_size);
+        bit_arrays.resize(bit_size);
+        for (ulint i = 0; i < bit_size; ++i) {
+            bit_arrays[i].load(in);
+        }
     }
+
+    // v[pos]
+    ulint at(ulint pos) {
+        assert(pos < this->size);
+
+        ulint c = 0;
+        for (ulint i = 0; i < bit_arrays.size(); ++i) {
+            ulint bit = bit_arrays.at(i).at(pos);   // もとの数値がのi番目のbit
+            c = (c <<= 1) | bit;
+            pos = bit_arrays.at(i).rank(pos, bit);
+            if (bit) {
+                pos += this->begin_one.at(i);
+            }
+        }
+        return c;
+    }
+
+    // v[0, pos)のcの数
+    ulint rank(ulint c, ulint pos) {
+        assert(pos <= size);
+        if (c >= maximum_element) {
+            return 0;
+        }
+
+        ulint left = 0, right = pos;
+        for (ulint i = 0; i < bit_size; ++i) {
+            const ulint bit = (c >> (bit_size - i - 1)) & 1;  // 上からi番目のbit
+            left = bit_arrays.at(i).rank(left, bit);             // cのi番目のbitと同じ数値の数
+            right = bit_arrays.at(i).rank(right, bit);           // cのi番目のbitと同じ数値の数
+            if (bit) {
+                left += this->begin_one.at(i);
+                right += this->begin_one.at(i);
+            }
+        }
+
+        return right - left;
+    }
+
+    // i番目のcの位置 + 1を返す。rankは1-origin
+    ulint select(ulint c, ulint rank) { // todo change to match rest of dyn
+        --rank; // hmm
+        assert(rank > 0);
+        assert(c < maximum_element);
+
+        ulint left = 0;
+        for (ulint i = 0; i < bit_size; ++i) {
+            const ulint bit = (c >> (bit_size - i - 1)) & 1;  // 上からi番目のbit
+            left = bit_arrays.at(i).rank(left, bit);               // cのi番目のbitと同じ数値の数
+            if (bit) {
+                left += this->begin_one.at(i);
+            }
+        }
+
+        ulint index = left + rank;
+        for (ulint i = 0; i < bit_arrays.size(); ++i){
+            ulint bit = ((c >> i) & 1);      // 下からi番目のbit
+            if (bit == 1) {
+                index -= this->begin_one.at(bit_size - i - 1);
+            }
+            //std::cerr << "selecting index " << index << " bit " << bit << std::endl;
+            index = this->bit_arrays.at(bit_size - i - 1).select(index, bit);
+        }
+        return index+1;
+    }
+
+    // posにcを挿入する
+    void insert(ulint pos, ulint c) {
+        assert(pos <= this->size);
+
+        for (ulint i = 0; i < bit_arrays.size(); ++i) {
+            const ulint bit = (c >> (bit_size - i - 1)) & 1;  //　上からi番目のbit
+            bit_arrays.at(i).insert(pos, bit);
+            pos = bit_arrays.at(i).rank(pos, bit);
+            if (bit) {
+                pos += this->begin_one.at(i);
+            }
+            else {
+                this->begin_one.at(i)++;
+            }
+        }
+
+        this->size++;
+    }
+
+    void push_front(ulint c) {
+        this->insert(0, c);
+    }
+
+    // 末尾にcを追加する
+    void push_back(ulint c) {
+        this->insert(this->size, c);
+    }
+
+    // posを削除する
+    void remove(ulint pos) {
+        assert(pos < this->size);
+        if (pos >= this->size) {
+            throw "Segmentation fault";
+        }
+
+        for (ulint i = 0; i < bit_arrays.size(); ++i) {
+            ulint bit = bit_arrays.at(i).at(pos);   // もとの数値のi番目のbit
+
+            auto next_pos = bit_arrays.at(i).rank(pos, bit);
+            bit_arrays.at(i).remove(pos);
+
+            if (bit) {
+                next_pos += this->begin_one.at(i);
+            }
+            else {
+                this->begin_one.at(i)--;
+            }
+            pos = next_pos;
+        }
+        this->size--;
+    }
+
+    // posにcをセットする
+    void update(ulint pos, ulint c) {
+        assert(pos < this->size);
+        this->remove(pos);
+        this->insert(pos, c);
+    }
+
+    // 他の操作は通常のWavelet Matrixと同じ
 
 private:
-
-    class node{
-
-    public:
-
-        //root constructor
-        node(){}
-
-        //parent constructor
-        node(node* parent_){
-
-            this->parent_ = parent_;
-
+    ulint get_num_of_bit(ulint x) {
+        if (x == 0) return 0;
+        x--;
+        ulint bit_num = 0;
+        while (x >> bit_num) {
+            ++bit_num;
         }
-
-        ~node(){
-
-            if(has_child0()){
-
-                delete child0_;
-                child0_=NULL;
-
-            }
-
-            if(has_child1()){
-
-                delete child1_;
-                child1_=NULL;
-
-            }
-
-        }
-
-        //turn this node into a leaf
-        void make_leaf(char_type c){
-
-            assert(not has_child0()); //musttnot have children
-            assert(not has_child1());
-            assert(bv.size()==0);
-
-            assert(not is_root()); //cannot make the root leaf
-
-            this->is_leaf_ = true;
-            this->l_=c;
-
-        }
-
-        //descend tree and return character at this position
-        char_type at(ulint i) const {
-
-            if(is_leaf()) return label();
-
-            assert(i<bv.size());
-
-            bool b = bv.at(i);
-
-            assert((b or has_child0()) and (not b or has_child1()));
-
-            if(b){
-
-                return child1_->at( bv.rank1(i) );
-
-            }
-
-            return child0_->at( bv.rank0(i) );
-
-        }
-
-        /*
-         * true iif code B has already been inserted
-         */
-        bool exists(vector<bool>& B, ulint j=0) const {
-
-            assert(j <= B.size());
-
-            //not at the end of B -> (B[j] -> must have child 1)
-            bool c1 = j==B.size() || (not B[j] || has_child1());
-
-            //not at the end of B -> (notB[j] -> must have child 0)
-            bool c0 = j==B.size() || (B[j] || has_child0());
-
-            return  (c1 and c0) &&
-                (
-                    j==B.size() ?
-                    true :
-                    (
-                        B[j] ?
-                        child1_->exists( B, j+1 ):
-                        child0_->exists( B, j+1 )
-                        )
-                    );
-
-        }
-
-        /*
-         * insert code B[j,...,B.size()-1] at position i. This code is associated
-         * with character c
-         */
-        void insert(ulint i, vector<bool>& B, char_type c, ulint j=0){
-
-            if(j==B.size()){
-
-                //this node must be a leaf
-                assert(bv.size()==0);
-
-                if(is_leaf()){
-
-                    //if it's already marked as leaf, check
-                    //that the label is correct
-                    assert(c==label());
-
-                }else{
-
-                    //else, mark node as leaf
-                    make_leaf(c);
-
-                }
-
-                return;
-
-            }
-
-            assert(i<=bv.size());
-            assert(not is_leaf());
-
-            bool b = B[j];
-            bv.insert(i,b);
-
-            if(b){
-
-                //if child does not exist, create it.
-                if(not has_child1()){
-                    child1_ = new node(this);
-                }
-
-                assert(j == B.size()-1 or bv.rank1(i) <= child1_->bv.size());
-
-                child1_->insert( bv.rank1(i), B, c, j+1 );
-
-            }else{
-
-                if(not has_child0()){
-                    child0_ = new node(this);
-                }
-
-                assert(j == B.size()-1 or  bv.rank0(i) <= child0_->bv.size());
-
-                child0_->insert( bv.rank0(i), B, c, j+1 );
-
-            }
-
-        }
-
-        /*
-         * remove code B[j,...,B.size()-1] from position i. This code is associated
-         * with character c
-         */
-        void remove(ulint i, vector<bool>& B, char_type c, ulint j=0){
-
-            if(j==B.size()){
-
-                //TODO: Check if leaf should be deleted?
-	       
-                //this node must be a leaf
-                assert(bv.size()==0);
-                assert( c == label() );
-                // if(is_leaf()){
-
-                // 	  //if it's already marked as leaf, check
-                // 	  //that the label is correct
-                // 	  assert(c==label());
-
-                // }else{
-
-                // 	  //else, mark node as leaf
-                // 	  make_leaf(c);
-
-                // }
-
-                return;
-
-            }
-
-            assert(i<=(bv.size() - 1));
-            assert(not is_leaf());
-
-            bool b = B[j];
-
-            assert(b == bv.at(i));
-
-            if(b){
-
-                //TODO: delete empty nodes?
-
-                assert(j == B.size()-1 or bv.rank1(i) <= child1_->bv.size());
-
-                child1_->remove( bv.rank1(i), B, c, j+1 );
-
-            }else{
-
-                assert(j == B.size()-1 or  bv.rank0(i) <= child0_->bv.size());
-
-                child0_->remove( bv.rank0(i), B, c, j+1 );
-
-            }
-
-            bv.remove(i);
-        }
-
-        ulint rank(ulint i, vector<bool>& B, ulint j=0) const {
-
-            assert(j <= B.size());
-
-            //not at the end of B -> (B[j] -> must have child 1)
-            assert(j==B.size() || (not B[j] || has_child1()));
-
-            //not at the end of B -> (notB[j] -> must have child 0)
-            assert(j==B.size() || (B[j] || has_child0()));
-
-            //not at the end of B -> i must be smaller than bv.size()
-            assert(j==B.size() || i<=bv.size());
-
-            return  j==B.size() ?
-                i :
-                (
-                    B[j] ?
-                    child1_->rank( bv.rank1(i), B, j+1 ):
-                    child0_->rank( bv.rank0(i), B, j+1 )
-                    );
-
-        }
-
-
-        ulint select(ulint i, vector<bool>& B) const {
-
-            //top-down: find leaf associated with B
-            const node* L = get_leaf(B);
-
-            auto p = L->parent_;
-
-            //bottom-up: from leaf to root
-            return p->select(i,B,B.size()-1);
-
-        }
-
-        ulint select(ulint i, vector<bool>& B, ulint j){
-
-            auto s = bv.select(i,B[j]);
-
-            return 	j==0 ?
-                s :
-                parent_->select( s, B, j-1);
-
-        }
-
-        //get leaf associated to code B
-        const node* get_leaf(vector<bool>& B, ulint j=0) const {
-
-            assert(j<=B.size());
-
-            return 	j==B.size() ? this :
-                (
-                    B[j]?
-                    child1_->get_leaf(B,j+1) :
-                    child0_->get_leaf(B,j+1)
-
-                    );
-
-        }
-
-        bool is_root() const { return not parent_; }
-        bool is_leaf() const { return is_leaf_; }
-        bool has_child0() const { return child0_; }
-        bool has_child1() const { return child1_; }
-
-        /*
-         * to have left label, this node must not have a left (0)
-         * child AND must have at least one bit equal to 0 in
-         * its bitvector
-         */
-        char_type label() const {
-
-            assert(is_leaf());
-            return l_;
-
-        }
-
-        /*
-         * Total number of bits allocated in RAM for this structure
-         *
-         * WARNING: this measure is good only for relatively small alphabets (e.g. ASCII)
-         * as we use STL containers such as set and map which do not give direct info on
-         * the total memory allocated. The sizes of these containers are proportional
-         * to the alphabet size (but the constants involved are high since internally
-         * they can use heavy structures as RBT)
-         */
-        ulint bit_size() const {
-            ulint size = sizeof(node)*8;
-
-            size += bv.bit_size();
-            if(child0_ != NULL)
-                size += child0_->bit_size();
-            if(child1_ != NULL)
-                size += child1_->bit_size();
-
-            return size;
-
-        }
-
-        ulint serialize(ostream &out) {
-
-            ulint w_bytes=0;
-
-            out.write((char*)&l_,sizeof(l_));
-            w_bytes += sizeof(l_);
-
-            out.write((char*)&is_leaf_,sizeof(is_leaf_));
-            w_bytes += sizeof(is_leaf_);
-
-            w_bytes += bv.serialize(out);
-
-            bool has_child0 = child0_ != NULL;
-            bool has_child1 = child1_ != NULL;
-
-            out.write((char*)&has_child0,sizeof(has_child0));
-            w_bytes += sizeof(has_child0);
-
-            out.write((char*)&has_child1,sizeof(has_child1));
-            w_bytes += sizeof(has_child1);
-
-            if(child0_) w_bytes += child0_->serialize(out);
-            if(child1_) w_bytes += child1_->serialize(out);
-
-            return w_bytes;
-
-        }
-
-        void load(istream &in){
-
-            in.read((char*)&l_,sizeof(l_));
-
-            in.read((char*)&is_leaf_,sizeof(is_leaf_));
-
-            bv.load(in);
-
-            bool has_child0;
-            bool has_child1;
-
-            in.read((char*)&has_child0,sizeof(has_child0));
-            in.read((char*)&has_child1,sizeof(has_child1));
-
-            child0_ = NULL;
-            child1_ = NULL;
-
-            if(has_child0){
-
-                child0_ = new node();
-                child0_->load(in);
-                child0_->parent_ = this;
-
-            }
-
-            if(has_child1){
-
-                child1_ = new node();
-                child1_->load(in);
-                child1_->parent_ = this;
-
-            }
-
-        }
-
-    private:
-
-        node child0(void) const;
-        node child1(void) const;
-        node parent0(void) const;
-        node parent1(void) const;
-
-        // the backing bitvectors, required by constructor
-        vector<dynamic_bitvector_t>* bv_ptr = nullptr;
-
-        // the Z_l values indicate the cut point for each level
-        vector<ulint>* z_val_ptr = nullptr;
-
-        // character start index
-        tsl::hopscotch_map<char_type, ulint>* C_ptr = nullptr;
-
-        //if is_leaf_, then node is labeled
-        char_type l_ = 0;
-        bool is_leaf_ = false;
-
-    };
-
-    //current length
-    ulint n = 0;
-
-    // the backing matrix
-    vector<dynamic_bitvector_t> bv;
-
-    // the z values for each level
-    vector<ulint> z_val;
-
-    // the character start index
-    tsl::hopscotch_map<char_type, ulint> C;
-
-    alphabet_encoder ae;
-
+        return bit_num;
+    }
 };
 
 }

--- a/include/internal/wm_string.hpp
+++ b/include/internal/wm_string.hpp
@@ -50,6 +50,31 @@ public:
         }
     }
 
+    // hack to accept an alphabet with frequencies, to match wt_string interface for testing
+    // doesn't work
+    /*
+    wm_string(vector<pair<ulint, double>>& P) {
+        n = 0;
+        sigma = 0;
+        for (auto& e : P) {
+            if (e.first > sigma) {
+                sigma = e.first;
+            }
+        }
+        ++sigma;
+        this->bit_width = this->get_num_of_bit(sigma-1);
+        if (bit_width == 0) {
+            bit_width = 1;
+        }
+        this->begin_one.resize(bit_width);
+
+        for (ulint i = 0; i < bit_width; ++i) {
+            dynamic_bitvector_t sv;
+            bit_arrays.push_back(sv);
+        }
+    }
+    */
+
     wm_string (ulint num_of_alphabet, const std::vector<ulint> &array) : n(0), sigma(num_of_alphabet + 1) {
         this->bit_width = this->get_num_of_bit(num_of_alphabet);
         if (bit_width == 0) {

--- a/wm_string.cpp
+++ b/wm_string.cpp
@@ -193,7 +193,7 @@ bool test_select(uint64_t num, uint64_t num_of_alphabet) {
         //cerr << data[i] << " ";
         count[data[i]]++;
     }
-    cerr << endl;
+    //cerr << endl;
 
     dyn::wm_str wm(num_of_alphabet, data);
 
@@ -337,6 +337,30 @@ bool test_update(uint64_t num, uint64_t num_of_alphabet) {
     return true;
 }
 
+bool test_serialize(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num);
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+    }
+
+    dyn::wm_str expected(num_of_alphabet, data);
+    string f = "wm_string.test.temp";
+    ofstream out(f.c_str());
+    expected.serialize(out);
+    out.close();
+    dyn::wm_str actual;
+    ifstream in(f.c_str());
+    actual.load(in);
+    in.close();
+    std::remove(f.c_str());
+
+    if (not same(expected, actual)) {
+        return false;
+    }
+
+    return true;
+}
+
 void speed_test(uint64_t num, uint64_t num_of_alphabet) {
     cout << "access:" << speed_access(num, num_of_alphabet) << "ms" << endl;
     cout << "rank:" << speed_rank(num, num_of_alphabet) << "ms" << endl;
@@ -356,6 +380,7 @@ bool test(uint64_t num, uint64_t num_of_alphabet) {
     cout << "test erase:" << (test_remove(num, num_of_alphabet) ? "OK" : "NG") << endl;
     cout << "test insert:" << (test_insert(num, num_of_alphabet) ? "OK" : "NG") << endl;
     cout << "test update:" << (test_update(num, num_of_alphabet) ? "OK" : "NG") << endl;
+    cout << "test serialize:" << (test_serialize(num, num_of_alphabet) ? "OK" : "NG") << endl;
 
     return ok;
 }

--- a/wm_string.cpp
+++ b/wm_string.cpp
@@ -1,0 +1,383 @@
+#include <bits/stdc++.h>
+#include <dynamic.hpp>
+
+using namespace std;
+
+unsigned long randxor(){
+    static unsigned long x=123456789,y=362436069,z=521288629,w=88675123;
+    unsigned long t;
+    t=(x^(x<<11));x=y;y=z;z=w;
+    return( w=(w^(w>>19))^(t^(t>>8)) );
+}
+
+double speed_access(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num);
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+    }
+
+    dyn::wm_str wm(num_of_alphabet, data);
+
+    int dummy = 0;
+    auto start = std::chrono::system_clock::now();
+    for (int i = 0; i < data.size(); ++i) {
+        if (wm.at(i) == -1) {
+            dummy++;
+        }
+    }
+    auto end = std::chrono::system_clock::now();
+    if (dummy) {
+        cout << "dummy" << endl;
+    }
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+double speed_rank(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num);
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+    }
+
+    dyn::wm_str wm(num_of_alphabet, data);
+
+    int dummy = 0;
+    auto start = std::chrono::system_clock::now();
+    for (uint64_t rank = 1; rank < data.size(); ++rank) {
+        uint64_t val = data[randxor() % num];
+        if (wm.rank(val, rank) == -1) {
+            dummy++;
+        }
+    }
+    auto end = std::chrono::system_clock::now();
+    if (dummy) {
+        cout << "dummy" << endl;
+    }
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+double speed_select(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num), count(num_of_alphabet, 0);
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+        count[data[i]]++;
+    }
+
+    dyn::wm_str wm(num_of_alphabet, data);
+
+    int dummy = 0;
+    auto start = std::chrono::system_clock::now();
+    for (int i = 0; i < num; ++i) {
+        uint64_t val = data[randxor() % num];
+        uint64_t rank  = randxor() % count.at(val) + 1;
+        if (wm.select(val, rank) == -1) {
+            dummy++;
+        }
+    }
+    auto end = std::chrono::system_clock::now();
+    if (dummy) {
+        cout << "dummy" << endl;
+    }
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+double speed_remove(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data;
+    for (int i = 0; i < num; ++i) {
+        data.emplace_back((uint64_t)randxor() % num_of_alphabet);
+    }
+
+    dyn::wm_str dwm(num_of_alphabet, data);
+
+    auto start = std::chrono::system_clock::now();
+    for (int i = 0; i < num; ++i) {
+        uint64_t pos = i == 0 ? 0 : randxor() % dwm.size;
+        dwm.remove(pos);
+    }
+    auto end = std::chrono::system_clock::now();
+    if (dwm.at(0) == 1) {
+        cout << "dummy" << endl;
+    }
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+double speed_insert(uint64_t num, uint64_t num_of_alphabet) {
+
+    dyn::wm_str dwm(num_of_alphabet);
+    auto start = std::chrono::system_clock::now();
+    for (int i = 0; i < num; ++i) {
+        uint64_t pos = i == 0 ? 0 : randxor() % i;
+        uint64_t c = randxor() % num_of_alphabet;
+        dwm.insert(pos, c);
+    }
+    auto end = std::chrono::system_clock::now();
+    if (dwm.at(0) == -1) {
+        cout << "dummy" << endl;
+    }
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+double speed_update(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data;
+    for (int i = 0; i < num; ++i) {
+        data.emplace_back((uint64_t)randxor() % num_of_alphabet);
+    }
+
+    dyn::wm_str dwm(num_of_alphabet, data);
+
+    auto start = std::chrono::system_clock::now();
+    for (int i = 0; i < num - 1; ++i) {
+        uint64_t pos = randxor() % data.size();
+        uint64_t c = randxor() % num_of_alphabet;
+        dwm.update(pos, c);
+    }
+    auto end = std::chrono::system_clock::now();
+    if (dwm.at(0) == -1) {
+        cout << "dummy" << endl;
+    }
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+bool test_access(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num);
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+    }
+
+    dyn::wm_str wm(num_of_alphabet, data);
+    for (int i = 0; i < data.size(); ++i) {
+        if (data[i] != wm.at(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool test_rank(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num);
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+    }
+
+    dyn::wm_str wm(num_of_alphabet, data);
+
+    set<uint64_t> s(data.begin(), data.end());
+    for (auto val : s) {
+        for (uint64_t i = 0; i < data.size(); ++i) {
+
+            int expected = 0;
+            for (int j = 0; j < i; ++j) {
+                expected += (data[j] == val);
+            }
+
+            if (wm.rank(val, i) != expected) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+
+bool test_select(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num), count(num_of_alphabet, 0);
+    //cerr << "data: ";
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+        //cerr << data[i] << " ";
+        count[data[i]]++;
+    }
+    cerr << endl;
+
+    dyn::wm_str wm(num_of_alphabet, data);
+
+    set<uint64_t> s(data.begin(), data.end());
+    for (auto val : s) {
+        //cerr << "selecting " << val << endl;
+        for (uint64_t rank = 1; rank < count.at(val); ++rank) {
+
+            uint64_t expected = 0;
+            int n = 0;
+            for (uint64_t i = 0; i < data.size(); ++i) {
+                n += (data.at(i) == val);
+                if (n == rank) {
+                    expected = i + 1;   // selectは見つけたindex+1
+                    break;
+                }
+            }
+
+            //cerr << "val/rank " << val << " " << rank << endl;
+            if (wm.select(val, rank) != expected) {
+                //cerr << "got " << wm.select(val, rank) << " but expected " << expected << endl;
+                return false;
+            } else {
+                //cerr << "got " << wm.select(val, rank) << endl;
+            }
+        }
+    }
+
+    return true;
+}
+
+// 2つの動的ビットベクトルが同じかチェック
+bool same(dyn::wm_str expected, dyn::wm_str actual) {
+
+    if (expected.size != actual.size) {
+        cout << "Error at n:" << " expected:" << expected.size << " actual: " << actual.size << endl;
+        return false;
+    }
+    if (expected.maximum_element != actual.maximum_element) {
+        cout << "Error at maximum_element:" << " expected:" << expected.maximum_element << " actual: " << actual.maximum_element << endl;
+        return false;
+    }
+    if (expected.bit_size != actual.bit_size) {
+        cout << "Error at num_of_bit:" << " expected:" << expected.bit_size << " actual: " << actual.bit_size << endl;
+        return false;
+    }
+    if (expected.begin_one != actual.begin_one) {
+        cout << "Error at begin_one" << endl;
+        assert(expected.begin_one.size() == actual.begin_one.size());
+        for (int i = 0; i < expected.begin_one.size(); ++i) {
+            if (expected.begin_one.at(i) != actual.begin_one.at(i)) {
+                cout << "begin_one[" << i << "] expected:" << expected.begin_one.at(i) << " actual: " << actual.begin_one.at(i) << endl;
+                return false;
+            }
+        }
+    }
+
+    for (int i = 0; i < expected.bit_arrays.size(); ++i) {
+        vector<uint64_t> expected_bits, actual_bits;
+
+        for (int j = 0; j < expected.bit_arrays.at(i).size(); ++j) {
+            expected_bits.emplace_back(expected.bit_arrays.at(i).at(j));
+        }
+        for (int j = 0; j < actual.bit_arrays.at(i).size(); ++j) {
+            actual_bits.emplace_back(actual.bit_arrays.at(i).at(j));
+        }
+
+        if (expected_bits != actual_bits) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool test_remove(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data;
+    for (int i = 0; i < num; ++i) {
+        data.emplace_back((uint64_t)randxor() % num_of_alphabet);
+    }
+
+    dyn::wm_str actual(num_of_alphabet, data);
+
+    for (int i = 0; i < num; ++i) {
+        uint64_t pos = i == 0 ? 0 : randxor() % data.size();
+        data.erase(data.begin() + pos);
+
+        dyn::wm_str expected(num_of_alphabet, data);
+        actual.remove(pos);
+
+        if (not same(expected, actual)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool test_insert(uint64_t num, uint64_t num_of_alphabet) {
+
+    dyn::wm_str actual(num_of_alphabet);
+    vector<uint64_t> data;
+    for (int i = 0; i < num; ++i) {
+        uint64_t pos = data.size() == 0 ? 0 : randxor() % data.size();
+        uint64_t c = randxor() % num_of_alphabet;
+
+        data.insert(data.begin() + pos, c);
+
+        dyn::wm_str expected(num_of_alphabet, data);
+
+        actual.insert(pos, c);
+        if (not same(expected, actual)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool test_update(uint64_t num, uint64_t num_of_alphabet) {
+    vector<uint64_t> data(num);
+    for (int i = 0; i < num; ++i) {
+        data[i] = (uint64_t)randxor() % num_of_alphabet;
+    }
+
+    dyn::wm_str actual(num_of_alphabet, data);
+
+    for (int i = 0; i < num - 1; ++i) {
+        uint64_t pos = randxor() % data.size();
+        uint64_t c = randxor() % num_of_alphabet;
+        data[pos] = c;
+
+        dyn::wm_str expected(num_of_alphabet, data);
+        actual.update(pos, c);
+
+        if (not same(expected, actual)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void speed_test(uint64_t num, uint64_t num_of_alphabet) {
+    cout << "access:" << speed_access(num, num_of_alphabet) << "ms" << endl;
+    cout << "rank:" << speed_rank(num, num_of_alphabet) << "ms" << endl;
+    cout << "select:" << speed_select(num, num_of_alphabet) << "ms" << endl;
+    cout << "insert:" << speed_insert(num, num_of_alphabet) << "ms" << endl;
+    cout << "erase:" << speed_remove(num, num_of_alphabet) << "ms" << endl;
+    cout << "update:" << speed_update(num, num_of_alphabet) << "ms" << endl;
+}
+
+
+bool test(uint64_t num, uint64_t num_of_alphabet) {
+    bool ok = true;
+
+    cout << "test access:" << ((ok &= test_access(num, num_of_alphabet)) ? "OK" : "NG") << endl;
+    cout << "test rank:" << ((ok &= test_rank(num, num_of_alphabet)) ? "OK" : "NG") << endl;
+    cout << "test select:" << ((ok &= test_select(num, num_of_alphabet)) ? "OK" : "NG") << endl;
+    cout << "test erase:" << (test_remove(num, num_of_alphabet) ? "OK" : "NG") << endl;
+    cout << "test insert:" << (test_insert(num, num_of_alphabet) ? "OK" : "NG") << endl;
+    cout << "test update:" << (test_update(num, num_of_alphabet) ? "OK" : "NG") << endl;
+
+    return ok;
+}
+
+int main() {
+
+    uint64_t num = 100000;
+    uint64_t num_of_alphabet = 10000000;
+
+    cout << "SPEED" << endl;
+    speed_test(num, num_of_alphabet);
+
+    cout << "TEST" << endl;
+    for (int i = 0; i < 1000; ++i) {
+        cout << "Test:" << i << endl;
+        num = randxor() % 100 + 1;
+        num_of_alphabet = randxor() % 50 + 1;
+        if (not test(num, num_of_alphabet)) {
+            cout << "ERROR" << endl;
+            break;
+        }
+    }
+
+    return 0;
+}

--- a/wm_string.cpp
+++ b/wm_string.cpp
@@ -45,7 +45,7 @@ double speed_rank(uint64_t num, uint64_t num_of_alphabet) {
     auto start = std::chrono::system_clock::now();
     for (uint64_t rank = 1; rank < data.size(); ++rank) {
         uint64_t val = data[randxor() % num];
-        if (wm.rank(val, rank) == -1) {
+        if (wm.rank(rank, val) == -1) {
             dummy++;
         }
     }
@@ -71,7 +71,7 @@ double speed_select(uint64_t num, uint64_t num_of_alphabet) {
     for (int i = 0; i < num; ++i) {
         uint64_t val = data[randxor() % num];
         uint64_t rank  = randxor() % count.at(val) + 1;
-        if (wm.select(val, rank) == -1) {
+        if (wm.select(rank, val) == -1) {
             dummy++;
         }
     }
@@ -93,7 +93,7 @@ double speed_remove(uint64_t num, uint64_t num_of_alphabet) {
 
     auto start = std::chrono::system_clock::now();
     for (int i = 0; i < num; ++i) {
-        uint64_t pos = i == 0 ? 0 : randxor() % dwm.size;
+        uint64_t pos = i == 0 ? 0 : randxor() % dwm.size();
         dwm.remove(pos);
     }
     auto end = std::chrono::system_clock::now();
@@ -175,7 +175,7 @@ bool test_rank(uint64_t num, uint64_t num_of_alphabet) {
                 expected += (data[j] == val);
             }
 
-            if (wm.rank(val, i) != expected) {
+            if (wm.rank(i, val) != expected) {
                 return false;
             }
         }
@@ -213,7 +213,7 @@ bool test_select(uint64_t num, uint64_t num_of_alphabet) {
             }
 
             //cerr << "val/rank " << val << " " << rank << endl;
-            if (wm.select(val, rank) != expected) {
+            if (wm.select(rank, val) != expected) {
                 //cerr << "got " << wm.select(val, rank) << " but expected " << expected << endl;
                 return false;
             } else {
@@ -228,16 +228,16 @@ bool test_select(uint64_t num, uint64_t num_of_alphabet) {
 // 2つの動的ビットベクトルが同じかチェック
 bool same(dyn::wm_str expected, dyn::wm_str actual) {
 
-    if (expected.size != actual.size) {
-        cout << "Error at n:" << " expected:" << expected.size << " actual: " << actual.size << endl;
+    if (expected.size() != actual.size()) {
+        cout << "Error at n:" << " expected:" << expected.size() << " actual: " << actual.size() << endl;
         return false;
     }
-    if (expected.maximum_element != actual.maximum_element) {
-        cout << "Error at maximum_element:" << " expected:" << expected.maximum_element << " actual: " << actual.maximum_element << endl;
+    if (expected.sigma != actual.sigma) {
+        cout << "Error at sigma:" << " expected:" << expected.sigma << " actual: " << actual.sigma << endl;
         return false;
     }
-    if (expected.bit_size != actual.bit_size) {
-        cout << "Error at num_of_bit:" << " expected:" << expected.bit_size << " actual: " << actual.bit_size << endl;
+    if (expected.bit_width != actual.bit_width) {
+        cout << "Error at num_of_bit:" << " expected:" << expected.bit_width << " actual: " << actual.bit_width << endl;
         return false;
     }
     if (expected.begin_one != actual.begin_one) {


### PR DESCRIPTION
This pulls in @MitI-7's [DynamicWaveletMatrix](https://github.com/MitI-7/WaveletMatrix/blob/master/DynamicWaveletMatrix/DynamicWaveletMatrix.hpp), rebases it on DYNAMIC's succinct bitvector, and partially matches the interface of wt_string.

It provides a fixed-width alphabet encoding requiring log(sigma) * N bits to encode N integers. I attempted to use it as a basis for the dynamic FM-index, but ran into problems that I assume relate to the fact that I'm not using an alphabet encoder like that in wt_string. However, I do pass the tests that @MitI-7 developed for the original implementation (these are in wm_string.cpp).

How can we improve this?