### PR TITLE
mmmulti requesting vgteam's DYNAMIC clone - what should Debian do?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(${INSTALL_DIR}/src/hopscotch_map/include)
 
 message("Building in ${CMAKE_BUILD_TYPE} mode")
 
-set(CMAKE_CXX_FLAGS "--std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 
 if(XXSDS_DYN_MULTI_THREADED)
   find_package(OpenMP REQUIRED)
@@ -42,9 +42,9 @@ if(XXSDS_DYN_MULTI_THREADED)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif(XXSDS_DYN_MULTI_THREADED)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g3 -ggdb")
-set(CMAKE_CXX_FLAGS_RELEASE "-ggdb -Ofast -fstrict-aliasing -DNDEBUG -march=native")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -ggdb -Ofast -fstrict-aliasing -march=native")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3 -ggdb")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ggdb -Ofast -fstrict-aliasing -DNDEBUG -march=native")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g -ggdb -Ofast -fstrict-aliasing -march=native")
 
 add_executable(debug debug.cpp)
 add_executable(rle_lz77_v1 rle_lz77_v1.cpp)

--- a/include/internal/hacked_vector.hpp
+++ b/include/internal/hacked_vector.hpp
@@ -27,16 +27,15 @@ public:
     }
 
     hv_reference const&operator=(uint64_t v) const {
-
-        _pv.set(_idx, v);
-
+        auto val = _pv.at(_idx);
+        _pv.increment(_idx, (val>v?val-v:v-val), v<val);
         return *this;
     }
 
     hv_reference const&operator=(hv_reference& ref) const {
-
-        _pv.set(_idx, uint64_t(ref));
-
+        auto val = _pv.at(_idx);
+        auto v = uint64_t(ref);
+        _pv.increment(_idx, (val>v?val-v:v-val), v<val);
         return *this;
     }
 


### PR DESCRIPTION
Hello,

DYNAMIC is a dependency of mmmulti (https://github.com/ekg/mmmulti/search?q=DYNAMIC&unscoped_q=DYNAMIC) which in turn is required as a dependency for seqwish which is referenced by a few workflows for Nanopore sequencing data, which we address as part fo the Covid-19 hackathon. Now, mmmulti explicitly references to a fork of yours (https://github.com/vgteam/DYNAMIC.git) to which then the author of mmmulti (@ekg) contributes.

This is a bit of a dilemma for the Linux distributions who tend to avoid shipping multiple versions of the same software. Preferably we would take the original, but if a change is important for the reverse dependency, then it is the fork that would be packaged. It is a bit weird that I now create a pull request even though I don't contribute to DYNAMIC at all. But since I could not place an issue with the vgteam's fork about it, and this button popped up suggesting a pull request - please forgive.

Please kindly comment on what would be the right thing for Debian to do. 

Many thanks!

Steffen
 