### PR TITLE
Upgrade C++ standard for hopscotch_map. Fixes #30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories(${INSTALL_DIR}/src/hopscotch_map/include)
 
 message("Building in ${CMAKE_BUILD_TYPE} mode")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++17")
 
 if(XXSDS_DYN_MULTI_THREADED)
   find_package(OpenMP REQUIRED)


### PR DESCRIPTION
Quick fix for issue #30 .

Apparently, hopscotch_map has upgraded, so either this project should upgrade its C++ standard, or a specific commit/tag of hopscotch should be added in the `ExternalProject_Add` command.

I prefer this way because C++17 has been around for a good bit, there should be no compatibility issues anymore.